### PR TITLE
switch from light grey to dark navy background for improved contrast

### DIFF
--- a/ofe_sphinx_theme/theme/ofe_sphinx_theme/sass/_colors.scss
+++ b/ofe_sphinx_theme/theme/ofe_sphinx_theme/sass/_colors.scss
@@ -69,8 +69,8 @@ html{
     --pst-color-shadow: #212121;
     --pst-color-border: silver;
     --pst-color-inline-code: var(--ofe-color-SergiosCousin);
-    --pst-color-target: var(--pst-color-info-highlight);;
-    --pst-color-background: var(--ofe-color-BeastlyLightGrey);
+    --pst-color-target: var(--pst-color-info-highlight);
+    --pst-color-background: #1d222d;
     --pst-color-on-background: #1e1e1e;
     --pst-color-surface: #666666;
     --pst-color-on-surface: #373737;


### PR DESCRIPTION
## Description

current:
![Screenshot 2025-04-04 at 4 46 17 PM](https://github.com/user-attachments/assets/5c3d764e-0134-4d27-b0d3-28894e98c380)



this PR:

![1d222d](https://github.com/user-attachments/assets/7ad35bc2-92e7-43c7-88fa-e764d2388ba9)
