### PR TITLE
bump pydata theme and python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.9"
 # Declare any run-time dependencies that should be installed with the package.
 dependencies = [
-   "pydata-sphinx-theme==0.14.*",
+   "pydata-sphinx-theme==0.16.*",
    "libsass",
 ]
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,7 +6,7 @@ build:
   image: latest
 
 python:
-  version: 3.10
+  version: 3.11
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Description
Bumping us to the latest pydata sphinx version (0.16). I tested this on pontibus and it quiets a lot of the deprecation warnings and builds successfully. 