### PR TITLE
Ensure PEP-639 Support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "versioningit"]
+requires = ["setuptools>=77.0.3", "versioningit"]
 build-backend = "setuptools.build_meta"
 
 # Self-descriptive entries which should always be present
@@ -12,10 +12,10 @@ readme = "README.md"
 authors = [
     { name = "The OpenFE developers", email = "openfreeenergy@omsf.io" }
 ]
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 # See https://pypi.org/classifiers/
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
Eventually (2026-Feb-18) the license field needs to be a SPDX license expression. The table with a "file" or "text" key is deprecated. As of version 77.0.3, setuptools supports this new format.

See:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

## Description
Provide a brief description of the PR's purpose here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go